### PR TITLE
Allow displayUsername to be used in command prelude

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -371,6 +371,7 @@ class Bot {
     const patternMap = {
       author,
       nickname: author,
+      displayUsername: author,
       text: withFormat,
       discordChannel: `#${discordChannel.name}`,
       ircChannel: channel


### PR DESCRIPTION
This allows displayUsername to be used in the command prelude. Before this change, if displayUsername was used in command prelude, it would not display correctly when a command was sent from IRC to Discord.